### PR TITLE
Enhances agent and tool URL handling and adds fallback

### DIFF
--- a/integrationtest/bl_agents.py
+++ b/integrationtest/bl_agents.py
@@ -4,7 +4,7 @@ from blaxel.agents import bl_agent
 
 
 async def main():
-    agent = bl_agent("vercel-first")
+    agent = bl_agent("template-google-adk-py")
     print(await agent.arun({"inputs": "Hello, world!"}))
     print(agent.run({"inputs": "Hello, world!"}))
 

--- a/integrationtest/global_hash.py
+++ b/integrationtest/global_hash.py
@@ -1,0 +1,3 @@
+from blaxel.common.internal import get_alphanumeric_limited_hash
+
+print(get_alphanumeric_limited_hash("dawa-function-pym", 48))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blaxel"
-version = "0.1.0"
+version = "0.1.8dev13"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "cploujoux", email = "cploujoux@blaxel.ai" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blaxel"
-version = "0.1.8dev13"
+version = "0.1.8dev15"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "cploujoux", email = "cploujoux@blaxel.ai" }]

--- a/src/blaxel/agents/__init__.py
+++ b/src/blaxel/agents/__init__.py
@@ -21,7 +21,7 @@ class BlAgent:
     def internal_url(self):
         """Get the internal URL for the agent using a hash of workspace and agent name."""
         hash = get_global_unique_hash(settings.workspace, "agent", self.name)
-        return f"{settings.run_internal_protocol}://{hash}.{settings.run_internal_hostname}"
+        return f"{settings.run_internal_protocol}://bl-{settings.env}-{hash}.{settings.run_internal_hostname}"
 
     @property
     def forced_url(self):

--- a/src/blaxel/common/autoload.py
+++ b/src/blaxel/common/autoload.py
@@ -1,10 +1,6 @@
-
-import logging
-
 from ..client import client
 from ..instrumentation.manager import telemetry_manager
 from .settings import settings
-
 
 def autoload() -> None:
     client.with_base_url(settings.base_url)

--- a/src/blaxel/common/internal.py
+++ b/src/blaxel/common/internal.py
@@ -38,7 +38,6 @@ def get_global_unique_hash(workspace: str, type: str, name: str) -> str:
     """
     global_unique_name = f"{workspace}-{type}-{name}"
     hash = get_alphanumeric_limited_hash(global_unique_name, 48)
-    logger.debug(f"Global unique name for {global_unique_name}: {hash}")
     return hash
 
 class Agent:

--- a/src/blaxel/common/internal.py
+++ b/src/blaxel/common/internal.py
@@ -1,0 +1,77 @@
+import base64
+import hashlib
+import os
+import re
+from typing import Optional
+from urllib.parse import urlparse
+
+
+def get_alphanumeric_limited_hash(input_str: str, max_size: int) -> str:
+    """
+    Generate a SHA-256 hash of the input string, convert it to base64,
+    remove non-alphanumeric characters, and limit the length.
+
+    Args:
+        input_str: The input string to hash
+        max_size: Maximum length of the output string
+
+    Returns:
+        A string containing only alphanumeric characters with length <= max_size
+    """
+    # Create SHA-256 hash
+    hash_obj = hashlib.sha256(input_str.encode())
+    # Get base64 representation
+    hash_b64 = base64.b64encode(hash_obj.digest()).decode()
+    # Remove non-alphanumeric characters
+    alphanumeric = re.sub(r'[^a-z0-9]', '', hash_b64.lower())
+    # Limit length
+    return alphanumeric[:max_size] if len(alphanumeric) > max_size else alphanumeric
+
+def get_global_unique_hash(workspace: str, type: str, name: str) -> str:
+    """
+    Generate a unique hash for a combination of workspace, type, and name.
+
+    Args:
+        workspace: The workspace identifier
+        type: The type identifier
+        name: The name identifier
+
+    Returns:
+        A unique alphanumeric hash string of maximum length 48
+    """
+    global_unique_name = f"{workspace}-{type}-{name}"
+    return get_alphanumeric_limited_hash(global_unique_name, 48)
+
+class Agent:
+    def __init__(self, agent_name: str, workspace: str, run_internal_protocol: str, run_internal_hostname: str):
+        self.agent_name = agent_name
+        self.workspace = workspace
+        self.run_internal_protocol = run_internal_protocol
+        self.run_internal_hostname = run_internal_hostname
+
+    @property
+    def internal_url(self) -> str:
+        """
+        Generate the internal URL for the agent using a unique hash.
+
+        Returns:
+            The internal URL as a string
+        """
+        hash_value = get_global_unique_hash(
+            self.workspace,
+            "agent",
+            self.agent_name
+        )
+        return f"{self.run_internal_protocol}://{hash_value}.{self.run_internal_hostname}"
+
+    @property
+    def forced_url(self) -> Optional[str]:
+        """
+        Check for a forced URL in environment variables.
+
+        Returns:
+            The forced URL if found in environment variables, None otherwise
+        """
+        env_var = self.agent_name.replace("-", "_").upper()
+        env_key = f"BL_AGENT_{env_var}_URL"
+        return os.environ.get(env_key)

--- a/src/blaxel/common/settings.py
+++ b/src/blaxel/common/settings.py
@@ -65,6 +65,11 @@ class Settings:
     def run_internal_hostname(self) -> str:
         """Get the run internal hostname."""
         return os.environ.get("BL_RUN_INTERNAL_HOSTNAME", "")
+    
+    @property
+    def bl_cloud(self) -> bool:
+        """Is running on bl cloud."""
+        return os.environ.get("BL_CLOUD", "") == "true"
 
     @property
     def run_internal_protocol(self) -> str:

--- a/src/blaxel/common/settings.py
+++ b/src/blaxel/common/settings.py
@@ -64,7 +64,12 @@ class Settings:
     @property
     def run_internal_hostname(self) -> str:
         """Get the run internal hostname."""
-        return os.environ.get("BL_RUN_INTERNAL_HOSTNAME", "internal.run.beamlit.net")
+        return os.environ.get("BL_RUN_INTERNAL_HOSTNAME", "")
+
+    @property
+    def run_internal_protocol(self) -> str:
+        """Get the run internal protocol."""
+        return os.environ.get("BL_RUN_INTERNAL_PROTOCOL", "https")
 
     @property
     def enable_opentelemetry(self) -> bool:

--- a/src/blaxel/common/settings.py
+++ b/src/blaxel/common/settings.py
@@ -21,7 +21,7 @@ class Settings:
     @property
     def log_level(self) -> str:
         """Get the log level."""
-        return os.environ.get("LOG_LEVEL", "INFO")
+        return os.environ.get("LOG_LEVEL", "INFO").upper()
 
     @property
     def base_url(self) -> str:

--- a/src/blaxel/mcp/server.py
+++ b/src/blaxel/mcp/server.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import uuid
 from contextlib import asynccontextmanager
 from typing import Dict, Literal
@@ -13,7 +14,6 @@ from websockets.server import WebSocketServerProtocol, serve
 
 from ..common.env import env
 from ..instrumentation.span import SpanManager
-import traceback
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,8 @@ class BlaxelMcpServerTransport:
                                 "mcp.message.parsed": True,
                                 "mcp.method": getattr(msg, "method", None),
                                 "mcp.messageId": getattr(msg, "id", None),
-                                "mcp.toolName": getattr(getattr(msg, "params", None), "name", None)
+                                "mcp.toolName": getattr(getattr(msg, "params", None), "name", None),
+                                "span.type": "mcp.message",
                             })
                             self.spans[client_id+":"+msg.id] =  span
                         await read_stream_writer.send(msg)

--- a/src/blaxel/tools/__init__.py
+++ b/src/blaxel/tools/__init__.py
@@ -32,7 +32,7 @@ class PersistentWebSocket:
         self.session: ClientSession = None
         self.timer_task = None
         self.tools_cache = []
-        if settings.run_internal_hostname:
+        if settings.bl_cloud:
             self.timeout_enabled = False
         else:
             self.timeout_enabled = timeout_enabled

--- a/src/blaxel/tools/__init__.py
+++ b/src/blaxel/tools/__init__.py
@@ -186,7 +186,6 @@ class BlTools:
     def _internal_url(self, name: str):
         """Get the internal URL for the agent using a hash of workspace and agent name."""
         hash = get_global_unique_hash(settings.workspace, "function", name)
-        logger.debug(f"Internal URL for {name}: {hash}.{settings.run_internal_hostname}")
         return f"{settings.run_internal_protocol}://bl-{settings.env}-{hash}.{settings.run_internal_hostname}"
 
     def _forced_url(self, name: str):


### PR DESCRIPTION
Improves URL management for agents and tools by introducing internal URLs based on a hash of workspace and name, and adds support for forced URLs via environment variables.

Also, implements a fallback mechanism for agent calls, allowing them to attempt a secondary URL if the primary one fails. This increases resilience by providing an alternative route when the primary agent endpoint is unavailable.

Adds tracing for tool listing and function calls and sets attributes to the spans.

Fix env usage